### PR TITLE
Fix appveyor push to nuget from master

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,5 +34,3 @@ deploy:
   api_key:
     secure: nuget_api_key
   artifact: '*.nupkg'
-  on:
-    branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,6 @@ deploy:
 - provider: NuGet
   api_key:
     secure: xxx
-  skip_symbols: true
   artifact: /.*\.nupkg/
 
 #  on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,11 +26,8 @@ before_build:
 after_build:
   - nuget pack src\Agoda.Analyzers.CodeFixes\Agoda.Analyzers.nuspec -Version %APPVEYOR_BUILD_VERSION%
 
+after_test:
+  - ps: "nuget push *.nupkg -ApiKey $env:nuget_api_key"
+
 artifacts:
   - path: '*.nupkg'
-
-deploy:
-- provider: NuGet
-  api_key:
-    secure: nuget_api_key
-  artifact: '*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,8 @@
+environment:
+  nuget_api_key:
+    secure: vxiVDKmWLJdCviOWaNdn9/GTRlDIE3nz/Al03uA5NOGrzd+7BUMrAME1g6k/Z/RR
 
+# version format
 version: 1.0.{build}
 skip_branch_with_pr: true
 image: Visual Studio 2017
@@ -26,11 +30,9 @@ artifacts:
   - path: '*.nupkg'
 
 deploy:
-  provider: NuGet
+- provider: NuGet
   api_key:
     secure: nuget_api_key
-  artifact: /.*\.nupkg/
-
-#  on:
-#    branch: master
-    #vxiVDKmWLJdCviOWaNdn9/GTRlDIE3nz/Al03uA5NOGrzd+7BUMrAME1g6k/Z/RR
+  artifact: '*.nupkg'
+  on:
+    branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,4 @@
-environment:
-  nuget_api_key:
-    secure: vxiVDKmWLJdCviOWaNdn9/GTRlDIE3nz/Al03uA5NOGrzd+7BUMrAME1g6k/Z/RR
 
-# version format
 version: 1.0.{build}
 skip_branch_with_pr: true
 image: Visual Studio 2017
@@ -26,8 +22,13 @@ before_build:
 after_build:
   - nuget pack src\Agoda.Analyzers.CodeFixes\Agoda.Analyzers.nuspec -Version %APPVEYOR_BUILD_VERSION%
 
-after_test:
-  - ps: "nuget push *.nupkg -ApiKey $env:nuget_api_key"
-
 artifacts:
   - path: '*.nupkg'
+
+deploy:
+  provider: NuGet
+  api_key:
+    secure: vxiVDKmWLJdCviOWaNdn9/GTRlDIE3nz/Al03uA5NOGrzd+7BUMrAME1g6k/Z/RR
+  artifact: /.*\.nupkg/
+  on:
+    branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,5 +32,6 @@ deploy:
     secure: vxiVDKmWLJdCviOWaNdn9/GTRlDIE3nz/Al03uA5NOGrzd+7BUMrAME1g6k/Z/RR
   skip_symbols: true
   artifact: /.*\.nupkg/
+
 #  on:
 #    branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 
-# version format
 version: 1.0.{build}
 skip_branch_with_pr: true
 image: Visual Studio 2017
@@ -29,9 +28,10 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: vxiVDKmWLJdCviOWaNdn9/GTRlDIE3nz/Al03uA5NOGrzd+7BUMrAME1g6k/Z/RR
+    secure: xxx
   skip_symbols: true
   artifact: /.*\.nupkg/
 
 #  on:
 #    branch: master
+    #vxiVDKmWLJdCviOWaNdn9/GTRlDIE3nz/Al03uA5NOGrzd+7BUMrAME1g6k/Z/RR

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ artifacts:
   - path: '*.nupkg'
 
 deploy:
-  provider: NuGet
+- provider: NuGet
   api_key:
     secure: vxiVDKmWLJdCviOWaNdn9/GTRlDIE3nz/Al03uA5NOGrzd+7BUMrAME1g6k/Z/RR
   skip_symbols: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,9 @@ artifacts:
   - path: '*.nupkg'
 
 deploy:
-- provider: NuGet
+  provider: NuGet
   api_key:
-    secure: xxx
+    secure: nuget_api_key
   artifact: /.*\.nupkg/
 
 #  on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,9 +30,10 @@ artifacts:
   - path: '*.nupkg'
 
 deploy:
-- provider: NuGet
+  provider: NuGet
   api_key:
     secure: nuget_api_key
-  artifact: '*.nupkg'
-  on:
-    branch: master
+  skip_symbols: true
+  artifact: /.*\.nupkg/
+#  on:
+#    branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,3 @@
-environment:
-  nuget_api_key:
-    secure: vxiVDKmWLJdCviOWaNdn9/GTRlDIE3nz/Al03uA5NOGrzd+7BUMrAME1g6k/Z/RR
 
 # version format
 version: 1.0.{build}
@@ -32,7 +29,7 @@ artifacts:
 deploy:
   provider: NuGet
   api_key:
-    secure: nuget_api_key
+    secure: vxiVDKmWLJdCviOWaNdn9/GTRlDIE3nz/Al03uA5NOGrzd+7BUMrAME1g6k/Z/RR
   skip_symbols: true
   artifact: /.*\.nupkg/
 #  on:

--- a/src/Agoda.Analyzers.CodeFixes/Agoda.Analyzers.nuspec
+++ b/src/Agoda.Analyzers.CodeFixes/Agoda.Analyzers.nuspec
@@ -11,6 +11,7 @@
     <copyright>Copyright © Agoda 2017</copyright>
     <projectUrl>https://github.com/agoda-com/AgodaAnalyzers</projectUrl>
     <iconUrl>https://avatars3.githubusercontent.com/u/19235448?s=200</iconUrl>
+    <licenseUrl>https://github.com/agoda-com/AgodaAnalyzers</licenseUrl>
   </metadata>
   <files>
     <file src="bin\Release\net462\Microsoft.CodeAnalysis.CSharp.dll" target="analyzers\dotnet\cs" />


### PR DESCRIPTION
Current appveyor logs 
```
Collecting artifacts...
Found artifact 'Agoda.Analyzers.1.0.39.nupkg' matching '*.nupkg' path
Uploading artifacts...
[1/1] Agoda.Analyzers.1.0.39.nupkg (3,694,619 bytes)...100%
"NuGet" deployment for branch "master" has been skipped because current branch is "fix-appveyor-nuget"
Build success
```

Nuget pack is there but not uploading