### PR TITLE
AG0027 Check CssSelector if it used with "[data-selenium"

### DIFF
--- a/src/Agoda.Analyzers.Test/AgodaCustom/AG0027UnitTests.cs
+++ b/src/Agoda.Analyzers.Test/AgodaCustom/AG0027UnitTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using System.Threading.Tasks;
+using Agoda.Analyzers.Test.Helpers;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Agoda.Analyzers.AgodaCustom;
+using System.Web;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+
+namespace Agoda.Analyzers.Test.AgodaCustom
+{
+    class AG0027UnitTests : DiagnosticVerifier
+    {
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new AG0027EnsureOnlyDataSeleniumIsUsedToFindElements();
+        }
+
+        [Test]
+        [TestCase("link[rel='link']")]
+        [TestCase("meta[name='meta']")]
+        [TestCase("form button.login-button")]
+        [TestCase(".class")]
+        [TestCase("#id")]
+        public async Task AG0027_WhenUsedForbiddenSelector_ThenShowWarning(string selectBy)
+        {
+            var testCode = $@"
+            using System;
+            using OpenQA.Selenium;
+            using OpenQA.Selenium.Chrome;
+            using System.Collections.ObjectModel;
+
+            namespace Selenium.Tests.Utils
+            {{
+                public class Utils
+                {{
+                    public ReadOnlyCollection<IWebElement> elements1 = new ChromeDriver().FindElements(By.CssSelector(""{selectBy}""));
+                    public IWebElement element1 = new ChromeDriver().FindElement(By.CssSelector(""{selectBy}""));
+                    public ReadOnlyCollection<IWebElement> elements2 = new ChromeDriver().FindElementsByCssSelector(""{selectBy}"");
+                    public IWebElement element2 = new ChromeDriver().FindElementByCssSelector(""{selectBy}"");
+                }}
+            }}";
+        
+        var analyzers = GetCSharpDiagnosticAnalyzers().ToImmutableArray();
+            var documents = CreateProject(new[] { testCode })
+                .AddMetadataReference(MetadataReference.CreateFromFile(typeof(IWebElement).Assembly.Location))
+                .AddMetadataReference(MetadataReference.CreateFromFile(typeof(ReadOnlyCollection<>).Assembly.Location))
+                .Documents
+                .ToArray();
+
+            var diag = await GetSortedDiagnosticsFromDocumentsAsync(analyzers, documents, CancellationToken.None).ConfigureAwait(false);
+
+            var baseResult = CSharpDiagnostic(AG0027EnsureOnlyDataSeleniumIsUsedToFindElements.DiagnosticId);
+            VerifyDiagnosticResults(diag, analyzers, new[]
+            {
+                baseResult.WithLocation(11, 104),
+                baseResult.WithLocation(12, 82),
+                baseResult.WithLocation(13, 72),
+                baseResult.WithLocation(14, 51)
+            });
+        }
+
+        [Test]
+        [TestCase("[data-selenium='hotel-item']")]
+        public async Task AG0027_WhenUsedProperSelector_ThenPass(string selectBy)
+        {
+            var testCode = $@"
+            using System;
+            using OpenQA.Selenium;
+            using OpenQA.Selenium.Chrome;
+            using System.Collections.ObjectModel;
+
+            namespace Selenium.Tests.Utils
+            {{
+                public class Utils
+                {{
+                    public ReadOnlyCollection<IWebElement> elements1 = new ChromeDriver().FindElements(By.CssSelector(""{selectBy}""));
+                    public IWebElement element1 = new ChromeDriver().FindElement(By.CssSelector(""{selectBy}""));
+                    public ReadOnlyCollection<IWebElement> elements2 = new ChromeDriver().FindElementsByCssSelector(""{selectBy}"");
+                    public IWebElement element2 = new ChromeDriver().FindElementByCssSelector(""{selectBy}"");
+                }}
+            }}";
+
+            var analyzers = GetCSharpDiagnosticAnalyzers().ToImmutableArray();
+            var documents = CreateProject(new[] { testCode })
+                .AddMetadataReference(MetadataReference.CreateFromFile(typeof(IWebElement).Assembly.Location))
+                .AddMetadataReference(MetadataReference.CreateFromFile(typeof(ReadOnlyCollection<>).Assembly.Location))
+                .Documents
+                .ToArray();
+
+            var diag = await GetSortedDiagnosticsFromDocumentsAsync(analyzers, documents, CancellationToken.None).ConfigureAwait(false);
+
+            CSharpDiagnostic(AG0027EnsureOnlyDataSeleniumIsUsedToFindElements.DiagnosticId);
+            VerifyDiagnosticResults(diag, analyzers, new DiagnosticResult[0]);
+        }   
+    }
+}

--- a/src/Agoda.Analyzers/Agoda.Analyzers.csproj
+++ b/src/Agoda.Analyzers/Agoda.Analyzers.csproj
@@ -77,6 +77,9 @@
     <None Update="RuleContent\AG0006RegisteredComponentShouldHaveExactlyOnePublicConstructor.html">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="RuleContent\AG0027EnsureOnlyDataSeleniumIsUsedToFindElements.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="RuleContent\AG0026EnsureOnlyCssSelectorIsUsedToFindElements.html">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Agoda.Analyzers/AgodaCustom/AG0027EnsureOnlyDataSeleniumIsUsedToFindElements.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0027EnsureOnlyDataSeleniumIsUsedToFindElements.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+using Agoda.Analyzers.Helpers;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Agoda.Analyzers.AgodaCustom
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AG0027EnsureOnlyDataSeleniumIsUsedToFindElements : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "AG0027";
+        private static readonly Regex MatchDataSelenium = new Regex("^[\\]?[\"]?\\[data-selenium=*");
+
+        private static readonly LocalizableResourceString Msg = new LocalizableResourceString(
+            nameof(CustomRulesResources.AG0027Title),
+            CustomRulesResources.ResourceManager,
+            typeof(CustomRulesResources));
+
+        private static readonly Action<SyntaxNodeAnalysisContext> AnalyzeSeleniumGetElement = HandleDependencyResolverUsage;
+
+        protected static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            DiagnosticId,
+            Msg,
+            Msg,
+            AnalyzerCategory.CustomQualityRules,
+            DiagnosticSeverity.Warning,
+            AnalyzerConstants.EnabledByDefault,
+            DescriptionContentLoader.GetAnalyzerDescription(nameof(AG0027EnsureOnlyDataSeleniumIsUsedToFindElements)),
+            "https://github.agodadev.io/pages/standards-c-sharp/code-standards/gui-testing/data-selenium.html",
+            WellKnownDiagnosticTags.EditAndContinue);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+        protected static ImmutableArray<ForbiddenInvocationRule> Rules =>
+            ImmutableArray.Create(
+                ForbiddenInvocationRule.Create(
+                    "OpenQA.Selenium.By",
+                    new Regex("^(CssSelector).*$")),
+                ForbiddenInvocationRule.Create(
+                    "OpenQA.Selenium.Remote.RemoteWebDriver",
+                    new Regex("^(FindElement[s]?ByCssSelector)$"))
+            );
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeSeleniumGetElement, SyntaxKind.InvocationExpression);
+        }
+
+        private static void HandleDependencyResolverUsage(SyntaxNodeAnalysisContext context)
+        {
+            var invocationExpressionSyntax = (InvocationExpressionSyntax)context.Node;
+
+            if (!(context.SemanticModel.GetSymbolInfo(invocationExpressionSyntax).Symbol is IMethodSymbol methodSymbol)) return;
+
+            if (Rules
+                .Where(rule => methodSymbol.ContainingType.ConstructedFrom.ToString() == rule.NamespaceAndType)
+                .Any(rule => !rule.ForbiddenIdentifierNameRegex.IsMatch(methodSymbol.Name))) return;
+
+            foreach (var argument in invocationExpressionSyntax.ArgumentList.Arguments)
+            {
+                if (MatchDataSelenium.IsMatch(argument.ToString())) return;
+
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Node.GetLocation()));
+            }
+        }
+    }
+}

--- a/src/Agoda.Analyzers/AgodaCustom/AG0027EnsureOnlyDataSeleniumIsUsedToFindElements.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0027EnsureOnlyDataSeleniumIsUsedToFindElements.cs
@@ -63,12 +63,9 @@ namespace Agoda.Analyzers.AgodaCustom
                 .Where(rule => methodSymbol.ContainingType.ConstructedFrom.ToString() == rule.NamespaceAndType)
                 .Any(rule => !rule.ForbiddenIdentifierNameRegex.IsMatch(methodSymbol.Name))) return;
 
-            foreach (var argument in invocationExpressionSyntax.ArgumentList.Arguments)
-            {
-                if (MatchDataSelenium.IsMatch(argument.ToString())) return;
+            if (MatchDataSelenium.IsMatch(invocationExpressionSyntax.ArgumentList.Arguments.FirstOrDefault().ToString())) return;
 
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Node.GetLocation()));
-            }
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Node.GetLocation()));
         }
     }
 }

--- a/src/Agoda.Analyzers/AgodaCustom/CustomRulesResources.Designer.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/CustomRulesResources.Designer.cs
@@ -257,7 +257,18 @@ namespace Agoda.Analyzers.AgodaCustom {
                 return ResourceManager.GetString("AG0026Title", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to only use data-selenium to find elements in Selenium tests.
+        /// </summary>
+        public static string AG0027Title
+        {
+            get
+            {
+                return ResourceManager.GetString("AG0027Title", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Prevent use of dynamic.
         /// </summary>

--- a/src/Agoda.Analyzers/AgodaCustom/ForbiddenMethodInvocationAnalyzerBase.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/ForbiddenMethodInvocationAnalyzerBase.cs
@@ -26,8 +26,7 @@ namespace Agoda.Analyzers.AgodaCustom
         private void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
         {
             var invocationExpressionSyntax = (InvocationExpressionSyntax)context.Node;
-            var methodSymbol = context.SemanticModel.GetSymbolInfo(invocationExpressionSyntax).Symbol as IMethodSymbol;
-            if (methodSymbol == null) return;
+            if (!(context.SemanticModel.GetSymbolInfo(invocationExpressionSyntax).Symbol is IMethodSymbol methodSymbol)) return;
 
             Rules
                 .Where(rule => methodSymbol.ContainingType.ConstructedFrom.ToString() == rule.NamespaceAndType)

--- a/src/Agoda.Analyzers/RuleContent/AG0027EnsureOnlyDataSeleniumIsUsedToFindElements.html
+++ b/src/Agoda.Analyzers/RuleContent/AG0027EnsureOnlyDataSeleniumIsUsedToFindElements.html
@@ -1,0 +1,30 @@
+﻿<h2>Use the <code>data-selenium</code> attribute to identify your elements</h2>
+<p> 
+     <ul>
+        <li>Make it simple to change HTML structure and CSS classes by identifying elements under test with the data-selenium HTML attribute, </li>
+        <li>rather than HTML tags, classes or IDs. The addition of data-selenium attributes may slightly increase the size of the page, but when</li>
+        <li>gzipped the difference will probably be negligable. We believe the trade off in developer productivity is worth it.</li>
+     </ul>
+</p>
+
+
+<h2>Don't</h2>
+<pre>
+        <![CDATA[ 
+        <form>
+            <button class="login-button">Log in</button>
+        </form>
+        ]]>
+
+    Driver.FindElement(By.CssSelector("form button.login-button"));
+</pre>
+
+<h2>Do</h2>
+<pre>
+         <![CDATA[ 
+        <form>
+            <button class="login-button" data-selenium="login-button">Log in</button>
+        </form>
+        ]]>
+    Driver.FindElement(By.CssSelector("[data-selenium=login-button]"));
+</pre>


### PR DESCRIPTION
Ensure argument to By.CssSelector matches the regex ^\[data-selenium=.

**Fail**
`By.CssSelector("h1")`
**Pass**
`By.CssSelector("[data-selenium=main-heading]")`

https://github.agodadev.io/pages/standards-c-sharp/code-standards/gui-testing/data-selenium.html