### PR TITLE
AG0030: Disallow dynamic as generic type parameter

### DIFF
--- a/src/Agoda.Analyzers.Test/AgodaCustom/AG0030UnitTests.cs
+++ b/src/Agoda.Analyzers.Test/AgodaCustom/AG0030UnitTests.cs
@@ -1,15 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
-using Agoda.Analyzers.AgodaCustom;
+﻿using Agoda.Analyzers.AgodaCustom;
 using Agoda.Analyzers.Test.Helpers;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Framework;
+using System.Threading.Tasks;
 
 namespace Agoda.Analyzers.Test.AgodaCustom
 {
@@ -22,7 +15,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
         [Test]
         public async Task AG0030_WhenNoDynamic_ShouldntShowWarning()
         {
-            var code = @"
+            string code = @"
 				class TestClass {
 					public void TestMethod1() {
 						int instance = 1;
@@ -40,7 +33,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
         [Test]
         public async Task AG0030_WhenMethodReturnsDynamic_ShowWarning()
         {
-            var code = @"
+            string code = @"
 				class TestClass {
 					public dynamic TestMethod2() {
 						return 1;
@@ -48,14 +41,14 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            var expected = new DiagnosticLocation(3, 6);
+            DiagnosticLocation expected = new DiagnosticLocation(3, 6);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenDynamicVariableDeclared_ShowWarning()
         {
-            var code = @"
+            string code = @"
 				class TestClass {
 					public void TestMethod1() {
 						dynamic instance = 1;
@@ -63,14 +56,14 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            var expected = new DiagnosticLocation(4, 7);
+            DiagnosticLocation expected = new DiagnosticLocation(4, 7);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenMultipleDynamicUsed_ShowWarning()
         {
-            var code = @"
+            string code = @"
 				class TestClass {
 					public dynamic TestMethod2() {
 						return 1;
@@ -82,7 +75,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            var expected = new[]
+            DiagnosticLocation[] expected = new[]
             {
                 new DiagnosticLocation(3, 6),
                 new DiagnosticLocation(8, 7)
@@ -93,7 +86,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
         [Test]
         public async Task AG0030_WhenReturnTypeContainsTheStringDynamic_ShouldntShowAnyWarning()
         {
-            var code = @"        
+            string code = @"        
                 class Xdynamic { }
  
                 class TestClass {
@@ -109,20 +102,20 @@ namespace Agoda.Analyzers.Test.AgodaCustom
         [Test]
         public async Task AG0030_WhenDynamicInInterface_ShowWarning()
         {
-            var code = @"
+            string code = @"
 				interface TestInterface {
 					dynamic TestMethod1();
 				}
 			";
 
-            var expected = new DiagnosticLocation(3, 6);
+            DiagnosticLocation expected = new DiagnosticLocation(3, 6);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenClassHasDynamicAsGenericParameter_ShouldShowWarning()
         {
-            var code = @"
+            string code = @"
 				class TestClass<T> {
 					public void TestMethod1() {
 						 var test = new TestClass<dynamic>();
@@ -130,14 +123,14 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            var expected = new DiagnosticLocation(4, 23);
+            DiagnosticLocation expected = new DiagnosticLocation(4, 23);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenClassHasDynamicAsOneOfManyGenericParameters_ShouldShowWarning()
         {
-            var code = @"
+            string code = @"
 				class TestClass<T1, T2, T3> {
 					public void TestMethod1() {
 						 var test = new TestClass<bool, dynamic, int>();
@@ -145,17 +138,67 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            var expected = new DiagnosticLocation(4, 23);
+            DiagnosticLocation expected = new DiagnosticLocation(4, 23);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenClassDoesNotHaveDynamicAsGenericParameter_ShouldNotShowWarning()
         {
-            var code = @"
+            string code = @"
 				class TestClass<T1, T2, T3> {
 					public void TestMethod1() {
 						 var test = new TestClass<bool, long, int>();
+					}
+				}
+			";
+
+            await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+        }
+
+        [Test]
+        public async Task AG0030_WhenMethodHasDynamicAsGenericParameter_ShouldShowWarning()
+        {
+            string code = @"
+				class TestClass {
+                    public void GenericMethod<T>() { }
+					
+                    public void TestMethod1() {
+						 GenericMethod<dynamic>();
+					}
+				}
+			";
+
+            DiagnosticLocation expected = new DiagnosticLocation(6, 8);
+            await VerifyDiagnosticsAsync(code, expected);
+        }
+
+        [Test]
+        public async Task AG0030_WhenMethodHasDynamicAsOneOfManyGenericParameters_ShouldShowWarning()
+        {
+            string code = @"
+				class TestClass {
+                    public void GenericMethod<T1, T2, T3, T4>() { }
+					
+                    public void TestMethod1() {
+						 GenericMethod<bool, long, dynamic, int>();
+					}
+				}
+			";
+
+            DiagnosticLocation expected = new DiagnosticLocation(6, 8);
+            await VerifyDiagnosticsAsync(code, expected);
+        }
+
+        [Test]
+        public async Task AG0030_WhenMethodDoesNotHaveDynamicAsGenericParameter_ShouldNotShowWarning()
+        {
+            string code = @"
+				class TestClass {
+                    public void GenericMethod<T1, T2, T3, T4>() { }
+					
+                    public void TestMethod1() {
+						 GenericMethod<bool, long, string, int>();
 					}
 				}
 			";

--- a/src/Agoda.Analyzers.Test/AgodaCustom/AG0030UnitTests.cs
+++ b/src/Agoda.Analyzers.Test/AgodaCustom/AG0030UnitTests.cs
@@ -15,10 +15,10 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 {
     internal class AG0030UnitTests : DiagnosticVerifier
     {
-	    protected override DiagnosticAnalyzer DiagnosticAnalyzer => new AG0030PreventUseOfDynamics();
-	    
-	    protected override string DiagnosticId => AG0030PreventUseOfDynamics.DIAGNOSTIC_ID;
-        
+        protected override DiagnosticAnalyzer DiagnosticAnalyzer => new AG0030PreventUseOfDynamics();
+
+        protected override string DiagnosticId => AG0030PreventUseOfDynamics.DIAGNOSTIC_ID;
+
         [Test]
         public async Task AG0030_WhenNoDynamic_ShouldntShowWarning()
         {
@@ -34,9 +34,9 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-	        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+            await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
         }
-        
+
         [Test]
         public async Task AG0030_WhenMethodReturnsDynamic_ShowWarning()
         {
@@ -51,7 +51,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
             var expected = new DiagnosticLocation(3, 6);
             await VerifyDiagnosticsAsync(code, expected);
         }
-        
+
         [Test]
         public async Task AG0030_WhenDynamicVariableDeclared_ShowWarning()
         {
@@ -66,7 +66,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
             var expected = new DiagnosticLocation(4, 7);
             await VerifyDiagnosticsAsync(code, expected);
         }
-        
+
         [Test]
         public async Task AG0030_WhenMultipleDynamicUsed_ShowWarning()
         {
@@ -89,7 +89,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
             };
             await VerifyDiagnosticsAsync(code, expected);
         }
-        
+
         [Test]
         public async Task AG0030_WhenReturnTypeContainsTheStringDynamic_ShouldntShowAnyWarning()
         {
@@ -119,7 +119,48 @@ namespace Agoda.Analyzers.Test.AgodaCustom
             await VerifyDiagnosticsAsync(code, expected);
         }
 
+        [Test]
+        public async Task AG0030_WhenClassHasDynamicAsGenericParameter_ShouldShowWarning()
+        {
+            var code = @"
+				class TestClass<T> {
+					public void TestMethod1() {
+						 var test = new TestClass<dynamic>();
+					}
+				}
+			";
 
-	    
+            var expected = new DiagnosticLocation(4, 23);
+            await VerifyDiagnosticsAsync(code, expected);
+        }
+
+        [Test]
+        public async Task AG0030_WhenClassHasDynamicAsOneOfManyGenericParameters_ShouldShowWarning()
+        {
+            var code = @"
+				class TestClass<T1, T2, T3> {
+					public void TestMethod1() {
+						 var test = new TestClass<bool, dynamic, int>();
+					}
+				}
+			";
+
+            var expected = new DiagnosticLocation(4, 23);
+            await VerifyDiagnosticsAsync(code, expected);
+        }
+
+        [Test]
+        public async Task AG0030_WhenClassDoesNotHaveDynamicAsGenericParameter_ShouldNotShowWarning()
+        {
+            var code = @"
+				class TestClass<T1, T2, T3> {
+					public void TestMethod1() {
+						 var test = new TestClass<bool, long, int>();
+					}
+				}
+			";
+
+            await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+        }
     }
 }

--- a/src/Agoda.Analyzers.Test/AgodaCustom/AG0030UnitTests.cs
+++ b/src/Agoda.Analyzers.Test/AgodaCustom/AG0030UnitTests.cs
@@ -15,7 +15,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
         [Test]
         public async Task AG0030_WhenNoDynamic_ShouldntShowWarning()
         {
-            string code = @"
+            var code = @"
 				class TestClass {
 					public void TestMethod1() {
 						int instance = 1;
@@ -33,7 +33,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
         [Test]
         public async Task AG0030_WhenMethodReturnsDynamic_ShowWarning()
         {
-            string code = @"
+            var code = @"
 				class TestClass {
 					public dynamic TestMethod2() {
 						return 1;
@@ -41,14 +41,14 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            DiagnosticLocation expected = new DiagnosticLocation(3, 6);
+            var expected = new DiagnosticLocation(3, 6);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenDynamicVariableDeclared_ShowWarning()
         {
-            string code = @"
+            var code = @"
 				class TestClass {
 					public void TestMethod1() {
 						dynamic instance = 1;
@@ -56,14 +56,14 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            DiagnosticLocation expected = new DiagnosticLocation(4, 7);
+            var expected = new DiagnosticLocation(4, 7);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenMultipleDynamicUsed_ShowWarning()
         {
-            string code = @"
+            var code = @"
 				class TestClass {
 					public dynamic TestMethod2() {
 						return 1;
@@ -75,7 +75,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            DiagnosticLocation[] expected = new[]
+            var expected = new[]
             {
                 new DiagnosticLocation(3, 6),
                 new DiagnosticLocation(8, 7)
@@ -86,7 +86,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
         [Test]
         public async Task AG0030_WhenReturnTypeContainsTheStringDynamic_ShouldntShowAnyWarning()
         {
-            string code = @"        
+            var code = @"        
                 class Xdynamic { }
  
                 class TestClass {
@@ -102,20 +102,20 @@ namespace Agoda.Analyzers.Test.AgodaCustom
         [Test]
         public async Task AG0030_WhenDynamicInInterface_ShowWarning()
         {
-            string code = @"
+            var code = @"
 				interface TestInterface {
 					dynamic TestMethod1();
 				}
 			";
 
-            DiagnosticLocation expected = new DiagnosticLocation(3, 6);
+            var expected = new DiagnosticLocation(3, 6);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenClassHasDynamicAsGenericParameter_ShouldShowWarning()
         {
-            string code = @"
+            var code = @"
 				class TestClass<T> {
 					public void TestMethod1() {
 						 var test = new TestClass<dynamic>();
@@ -123,14 +123,14 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            DiagnosticLocation expected = new DiagnosticLocation(4, 23);
+            var expected = new DiagnosticLocation(4, 23);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenClassHasDynamicAsOneOfManyGenericParameters_ShouldShowWarning()
         {
-            string code = @"
+            var code = @"
 				class TestClass<T1, T2, T3> {
 					public void TestMethod1() {
 						 var test = new TestClass<bool, dynamic, int>();
@@ -138,14 +138,14 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            DiagnosticLocation expected = new DiagnosticLocation(4, 23);
+            var expected = new DiagnosticLocation(4, 23);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenClassDoesNotHaveDynamicAsGenericParameter_ShouldNotShowWarning()
         {
-            string code = @"
+            var code = @"
 				class TestClass<T1, T2, T3> {
 					public void TestMethod1() {
 						 var test = new TestClass<bool, long, int>();
@@ -159,7 +159,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
         [Test]
         public async Task AG0030_WhenMethodHasDynamicAsGenericParameter_ShouldShowWarning()
         {
-            string code = @"
+            var code = @"
 				class TestClass {
                     public void GenericMethod<T>() { }
 					
@@ -169,14 +169,14 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            DiagnosticLocation expected = new DiagnosticLocation(6, 8);
+            var expected = new DiagnosticLocation(6, 8);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenMethodHasDynamicAsOneOfManyGenericParameters_ShouldShowWarning()
         {
-            string code = @"
+            var code = @"
 				class TestClass {
                     public void GenericMethod<T1, T2, T3, T4>() { }
 					
@@ -186,14 +186,14 @@ namespace Agoda.Analyzers.Test.AgodaCustom
 				}
 			";
 
-            DiagnosticLocation expected = new DiagnosticLocation(6, 8);
+            var expected = new DiagnosticLocation(6, 8);
             await VerifyDiagnosticsAsync(code, expected);
         }
 
         [Test]
         public async Task AG0030_WhenMethodDoesNotHaveDynamicAsGenericParameter_ShouldNotShowWarning()
         {
-            string code = @"
+            var code = @"
 				class TestClass {
                     public void GenericMethod<T1, T2, T3, T4>() { }
 					

--- a/src/Agoda.Analyzers/AgodaCustom/AG0030PreventUseOfDynamics.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0030PreventUseOfDynamics.cs
@@ -14,12 +14,12 @@ namespace Agoda.Analyzers.AgodaCustom
         public const string DIAGNOSTIC_ID = "AG0030";
 
         private static readonly LocalizableString Title = new LocalizableResourceString(
-            nameof(CustomRulesResources.AG0030Title), 
+            nameof(CustomRulesResources.AG0030Title),
             CustomRulesResources.ResourceManager,
             typeof(CustomRulesResources));
 
         private static readonly LocalizableString MessageFormat = new LocalizableResourceString(
-            nameof(CustomRulesResources.AG0030Title), 
+            nameof(CustomRulesResources.AG0030Title),
             CustomRulesResources.ResourceManager,
             typeof(CustomRulesResources));
 
@@ -27,13 +27,13 @@ namespace Agoda.Analyzers.AgodaCustom
             DescriptionContentLoader.GetAnalyzerDescription(nameof(AG0030PreventUseOfDynamics));
 
         private static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
-            DIAGNOSTIC_ID, 
-            Title, 
-            MessageFormat, 
+            DIAGNOSTIC_ID,
+            Title,
+            MessageFormat,
             AnalyzerCategory.CustomQualityRules,
-            DiagnosticSeverity.Warning, 
-            AnalyzerConstants.EnabledByDefault, 
-            Description, 
+            DiagnosticSeverity.Warning,
+            AnalyzerConstants.EnabledByDefault,
+            Description,
             "https://agoda-com.github.io/standards-c-sharp/code-style/dynamics.html",
             WellKnownDiagnosticTags.EditAndContinue);
 
@@ -41,28 +41,41 @@ namespace Agoda.Analyzers.AgodaCustom
         {
             context.RegisterSyntaxNodeAction(AnalyzeVariableDeclaration, SyntaxKind.VariableDeclaration);
             context.RegisterSyntaxNodeAction(AnalyzeMethodDeclaration, SyntaxKind.MethodDeclaration);
+            context.RegisterSyntaxNodeAction(AnalyzeGenericName, SyntaxKind.GenericName);
         }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
 
         private void AnalyzeVariableDeclaration(SyntaxNodeAnalysisContext context)
         {
-            var variableDeclaration = (VariableDeclarationSyntax) context.Node;
+            var variableDeclaration = (VariableDeclarationSyntax)context.Node;
             if (ValidateReturnType(variableDeclaration.Type)) return;
             context.ReportDiagnostic(Diagnostic.Create(Descriptor, variableDeclaration.GetLocation()));
         }
 
         private void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
         {
-            var methodDeclaration = (MethodDeclarationSyntax) context.Node;
+            var methodDeclaration = (MethodDeclarationSyntax)context.Node;
             if (ValidateReturnType(methodDeclaration.ReturnType)) return;
             context.ReportDiagnostic(Diagnostic.Create(Descriptor, methodDeclaration.GetLocation()));
+        }
+
+        private void AnalyzeGenericName(SyntaxNodeAnalysisContext context)
+        {
+            var genericName = (GenericNameSyntax)context.Node;
+            if (ValidateGenericType(genericName)) return;
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, genericName.GetLocation()));
         }
 
         private bool ValidateReturnType(TypeSyntax returnTypeSyntax)
         {
             var returnType = returnTypeSyntax.GetText().ToString().Trim();
             return returnType != "dynamic";
+        }
+
+        private bool ValidateGenericType(GenericNameSyntax genericName)
+        {
+            return genericName.TypeArgumentList.Arguments.All(argument => argument.GetText().ToString() != "dynamic");
         }
     }
 }


### PR DESCRIPTION
To warn us when magic like these is about to happen:
```csharp
class TestClass<T> 
{
    public void TestMethod1() 
    {
        var test = new TestClass<dynamic>();
    }
}
```
and
```csharp
class TestClass 
{
    public void GenericMethod<T>() { }

    public void TestMethod1() 
    {
         GenericMethod<dynamic>();
    }
}
```