### PR TITLE
AG0018: Fix false positive in methods returning byte[] 

### DIFF
--- a/src/Agoda.Analyzers.Test/AgodaCustom/AG0018UnitTests.cs
+++ b/src/Agoda.Analyzers.Test/AgodaCustom/AG0018UnitTests.cs
@@ -40,6 +40,7 @@ namespace Agoda.Analyzers.Test.AgodaCustom
                             public IDictionary<string, string> GetServerDnsV2() { return null; }
                             public IReadOnlyDictionary<string, int> GetNumberOfServerV2() { return null; }
                             public KeyedCollection<string, string> GetServerDnsV3() { return null; }
+                            public byte[] GetRawData() { return null; }
                             public int NumberOfServer { get; set; }
                             public byte[] RawData { get; set; }
                             public string DNSName { get; set; }

--- a/src/Agoda.Analyzers/AgodaCustom/AG0018PermitOnlyCertainPubliclyExposedEnumerables.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0018PermitOnlyCertainPubliclyExposedEnumerables.cs
@@ -71,7 +71,7 @@ namespace Agoda.Analyzers.AgodaCustom
                 IMethodSymbol method = (IMethodSymbol)symbol;
                 if(method.ReturnType is IArrayTypeSymbol)
                 {
-                    if ((method.ReturnType as IArrayTypeSymbol).ElementType.Name != "byte")
+                    if ((method.ReturnType as IArrayTypeSymbol).ElementType.Name != "Byte")
                     {
                         return false;
                     }

--- a/src/Agoda.Analyzers/RuleContent/AG0018PermitOnlyCertainPubliclyExposedEnumerables.html
+++ b/src/Agoda.Analyzers/RuleContent/AG0018PermitOnlyCertainPubliclyExposedEnumerables.html
@@ -1,13 +1,13 @@
 ﻿ <p>
-     If `public` class/interface method/property return value implements `IEnumerable`, then it can _only_ be declared as one of the following:
-     - `IEnumerable&lt;T&gt;`
-     - `ISet&lt;T&gt;`
-     - `IList&lt;T&gt;`
-     - `IDictionary&lt;K, V&gt;`
-     - `IReadOnlyDictionary&lt;K, V&gt;`
-     - `KeyedCollection&lt;K, V&gt;`
-     - `byte[]` (special case for raw binary data)
-     - `string` (which happens to implement `IEnumerable&lt;char&gt;`)
+     If <code>public</code> class/interface method/property return value implements <code>IEnumerable</code>, then it can <i>only</i> be declared as one of the following:
+     - <code>IEnumerable&lt;T&gt;</code>
+     - <code>ISet&lt;T&gt;</code>
+     - <code>IList&lt;T&gt;</code>
+     - <code>IDictionary&lt;K, V&gt;</code>
+     - <code>IReadOnlyDictionary&lt;K, V&gt;</code>
+     - <code>KeyedCollection&lt;K, V&gt;</code>
+     - <code>byte[]</code> (special case for raw binary data)
+     - <code>string</code> (which happens to implement `IEnumerable&lt;char&gt;`)
  </p>
 
 


### PR DESCRIPTION
Methods with `byte[]`-returning signature were incorrectly identified as rule-breakers.

Eg. the following method reports, but should not report.
```csharp
public byte[] GetRawData() { return null; }
```

The rule implementation for `byte[]`-returning properties was already correct.

Fixed a typo causing this bug, and added test-coverage for this case.
Also fixed the documentation of the rule to use html formatting instead of markdown, to work properly on SonarQube UI.