### PR TITLE
Improve the error message shown for AG0018: 

### DIFF
--- a/src/Agoda.Analyzers/AgodaCustom/AG0018PermitOnlyCertainPubliclyExposedEnumerables.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0018PermitOnlyCertainPubliclyExposedEnumerables.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AG0018EnsureThatPubliclyExposedIEnumerableTypes.cs" company="Agoda Company Co., Ltd.">
+﻿// <copyright file="AG0018PermitOnlyCertainPubliclyExposedEnumerables.cs" company="Agoda Company Co., Ltd.">
 // AGODA ® is a registered trademark of AGIP LLC, used under license by Agoda Company Co., Ltd.. Agoda is part of Priceline (NASDAQ:PCLN)
 // </copyright>
 using System.Collections.Immutable;

--- a/src/Agoda.Analyzers/AgodaCustom/CustomRulesResources.Designer.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/CustomRulesResources.Designer.cs
@@ -232,7 +232,7 @@ namespace Agoda.Analyzers.AgodaCustom {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ensure that publicly exposed IEnumerable types.
+        ///   Looks up a localized string similar to AG0018: Ensure that publicly exposed enumerable types are on our whitelist.
         /// </summary>
         public static string AG0018Title {
             get {

--- a/src/Agoda.Analyzers/AgodaCustom/CustomRulesResources.resx
+++ b/src/Agoda.Analyzers/AgodaCustom/CustomRulesResources.resx
@@ -198,7 +198,7 @@
     <value>Prevent use of dynamic</value>
   </data>
   <data name="AG0018Title" xml:space="preserve">
-    <value>Ensure that publicly exposed IEnumerable types</value>
+    <value>Invalid return type. Publicly exposed enumerable types must be on our whitelist.</value>
   </data>
   <data name="AG0026Title" xml:space="preserve">
     <value>Use only CSS Selectors to find elements in Selenium tests</value>


### PR DESCRIPTION
The message shown when `AG0018` is violated is quite confusing:
```
Ensure that publicly exposed IEnumerable types
```

This PR will change it to the following:
```
Invalid return type. Publicly exposed enumerable types must be on our whitelist.
```

Also updated some inconsistencies in how this rule is referred to in other places.

Fixes #149