### PR TITLE
Add Rule for public Member Documentation in Libraries

### DIFF
--- a/src/Agoda.Analyzers.Test/AgodaCustom/AG0039UnitTests.cs
+++ b/src/Agoda.Analyzers.Test/AgodaCustom/AG0039UnitTests.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using Agoda.Analyzers.AgodaCustom;
+using Agoda.Analyzers.Test.Helpers;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Agoda.Analyzers.Test.AgodaCustom;
+
+class AG0039UnitTests : DiagnosticVerifier
+{
+    protected override DiagnosticAnalyzer DiagnosticAnalyzer => new AG0039UndocumentedMemberAnalyzer();
+
+    protected override string DiagnosticId => AG0039UndocumentedMemberAnalyzer.DIAGNOSTIC_ID;
+
+    [Test]
+    public async Task AG0037_WithRegion_ShowsWarning()
+    {
+        var code = @"
+				public class NotDoc
+				{
+					public string str1 {get;}
+					public const int int2 = 1;
+                    public void DoesNothing() {}
+                    public event SampleEventHandler SampleEvent;
+                    public delegate void SampleEventHandler(object sender);
+				}
+			";
+        
+        await VerifyDiagnosticsAsync(code, new []{
+            new DiagnosticLocation(2, 18),
+            new DiagnosticLocation(4, 20),
+            new DiagnosticLocation(4, 26),
+            new DiagnosticLocation(5, 23),
+            new DiagnosticLocation(6, 33),
+            new DiagnosticLocation(7, 53),
+            new DiagnosticLocation(8, 42),
+        });
+    }
+}

--- a/src/Agoda.Analyzers.Test/AgodaCustom/AG0039UnitTests.cs
+++ b/src/Agoda.Analyzers.Test/AgodaCustom/AG0039UnitTests.cs
@@ -23,7 +23,27 @@ class AG0039UnitTests : DiagnosticVerifier
                     public void DoesNothing() {}
                     public event SampleEventHandler SampleEvent;
                     public delegate void SampleEventHandler(object sender);
+                    internal string internalString;
+                    internal string internalStringProp {get;}
+                    protected string protectedString;
+                    private int _privateInt;
 				}
+                internal class InternalClass
+                {
+                    public string str1 {get;}
+                    public const int int2 = 1;
+                    public void DoesNothing() {}
+                    public event SampleEventHandler SampleEvent;
+                    public delegate void SampleEventHandler(object sender);
+                    internal string internalString;
+                    internal string internalStringProp {get;}
+                    protected string protectedString;
+                    private int _privateInt;
+
+                    private class MyClass
+                    {
+                    }
+                }
 			";
         
         await VerifyDiagnosticsAsync(code, new []{
@@ -34,6 +54,12 @@ class AG0039UnitTests : DiagnosticVerifier
             new DiagnosticLocation(6, 33),
             new DiagnosticLocation(7, 53),
             new DiagnosticLocation(8, 42),
+            new DiagnosticLocation(16, 35),
+            new DiagnosticLocation(16, 41),
+            new DiagnosticLocation(17, 38),
+            new DiagnosticLocation(18, 33),
+            new DiagnosticLocation(19, 53),
+            new DiagnosticLocation(20, 42)
         });
     }
 }

--- a/src/Agoda.Analyzers.Test/Helpers/DiagnosticVerifier.cs
+++ b/src/Agoda.Analyzers.Test/Helpers/DiagnosticVerifier.cs
@@ -113,8 +113,6 @@ public abstract partial class DiagnosticVerifier
             .AddMetadataReference(MetadataReference.CreateFromFile(typeof(Type).GetTypeInfo().Assembly.Location.Replace("System.Private.CoreLib", "System.Runtime")))
             .AddMetadataReference(MetadataReference.CreateFromFile(typeof(Type).GetTypeInfo().Assembly.Location.Replace("System.Private.CoreLib", "System.Threading.Tasks")))
             .AddMetadataReference(MetadataReference.CreateFromFile(typeof(Type).GetTypeInfo().Assembly.Location.Replace("System.Private.CoreLib", "System.ObjectModel")))
-            //System.Collections.ObjectModel
-            
             .Documents
             .First();
 

--- a/src/Agoda.Analyzers/AgodaCustom/AG0039UndocumentedMemberAnalyzer.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0039UndocumentedMemberAnalyzer.cs
@@ -29,7 +29,7 @@ namespace Agoda.Analyzers.AgodaCustom
             Title,
             MessageFormat,
             Category,
-            DiagnosticSeverity.Hidden,
+            DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: "Public surfaces should be documented, please add XML documentation.");
 

--- a/src/Agoda.Analyzers/AgodaCustom/AG0039UndocumentedMemberAnalyzer.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0039UndocumentedMemberAnalyzer.cs
@@ -29,7 +29,7 @@ namespace Agoda.Analyzers.AgodaCustom
             Title,
             MessageFormat,
             Category,
-            DiagnosticSeverity.Warning,
+            DiagnosticSeverity.Hidden,
             isEnabledByDefault: true,
             description: "Public surfaces should be documented, please add XML documentation.");
 

--- a/src/Agoda.Analyzers/AgodaCustom/AG0039UndocumentedMemberAnalyzer.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0039UndocumentedMemberAnalyzer.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Immutable;
+using Agoda.Analyzers.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Agoda.Analyzers.AgodaCustom
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AG0039UndocumentedMemberAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DIAGNOSTIC_ID = "AG0039";
+
+        private static readonly LocalizableString Title = new LocalizableResourceString(
+            nameof(CustomRulesResources.AG0039Title),
+            CustomRulesResources.ResourceManager,
+            typeof(CustomRulesResources));
+
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(
+            nameof(CustomRulesResources.AG0039Title),
+            CustomRulesResources.ResourceManager,
+            typeof(CustomRulesResources));
+
+        private static readonly LocalizableString Description
+            = DescriptionContentLoader.GetAnalyzerDescription(nameof(AG0039UndocumentedMemberAnalyzer));
+
+        private const string Category = "Documentation";
+        private static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            DIAGNOSTIC_ID,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "Public surfaces should be documented, please add XML documentation.");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType, SymbolKind.Method, SymbolKind.Property, SymbolKind.Field, SymbolKind.Event);
+        }
+
+        private static void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            if (context.Symbol.DeclaredAccessibility != Accessibility.Public)
+                return;
+
+            if (!string.IsNullOrWhiteSpace(context.Symbol.GetDocumentationCommentXml()))
+                return;
+
+            var location = context.Symbol.Locations[0];
+            var name = context.Symbol.Name;
+
+            var diagnostic = Diagnostic.Create(Descriptor, location, context.Symbol.Kind.ToString(), name);
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/src/Agoda.Analyzers/AgodaCustom/CustomRulesResources.Designer.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/CustomRulesResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Agoda.Analyzers.AgodaCustom {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class CustomRulesResources {
@@ -437,6 +437,15 @@ namespace Agoda.Analyzers.AgodaCustom {
         public static string AG0038Title {
             get {
                 return ResourceManager.GetString("AG0038Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Libraries with Public members must have documentation.
+        /// </summary>
+        public static string AG0039Title {
+            get {
+                return ResourceManager.GetString("AG0039Title", resourceCulture);
             }
         }
     }

--- a/src/Agoda.Analyzers/AgodaCustom/CustomRulesResources.resx
+++ b/src/Agoda.Analyzers/AgodaCustom/CustomRulesResources.resx
@@ -248,4 +248,7 @@ One exception is logging, where it can be useful to see the exact DC / cluster /
   <data name="AG0038Title" xml:space="preserve">
     <value>Do not use #region directives</value>
   </data>
+  <data name="AG0039Title" xml:space="preserve">
+    <value>Libraries with Public members must have documentation</value>
+  </data>
 </root>

--- a/src/Agoda.Analyzers/RuleContent/AG0039UndocumentedMemberAnalyzer.html
+++ b/src/Agoda.Analyzers/RuleContent/AG0039UndocumentedMemberAnalyzer.html
@@ -1,0 +1,19 @@
+﻿<p>
+    Public members should be documented or made internal
+</p>
+<ul>
+    <li>
+        This rule is intended for libraries, it helps other people understand how to use teh code you publish. 
+    </li>
+    <li>
+        We follow Docs as Code (https://www.writethedocs.org/guide/docs-as-code/), so we want to document the code in the code, not in a separate document.
+        This helps ensure that we can the documentation updated, as we can use the same tools we use for code to ensure we update the documentation.
+        For example, this static code analysis rule
+    </li>
+    <li>
+        Recommend using it with tools like DocFx to complete the documentation loop from code to make it easier for people to consume. 
+    </li>
+    <li>
+        Or make them internal, sometimes you don''t want to documentation them because you don't intend people to use them, if this is the case, make them internal. 
+    </li>
+</ul>


### PR DESCRIPTION
We've been talking before about the difference in standards between web sites and libraries.

This rule is specifically for libraries, where we want strong documentation. I'm thinking by default we leave it as hidden rule, then only on the projects, or in particular I think it'll be areas of projects they want to enable this.

I'd like to add it to our internal library template as error to begin with then expand from there. 