### PR TITLE
Fix compile errors by removing reference to non-existing Agoda.Analyzers.CodeFixes project

### DIFF
--- a/src/Agoda.Analyzers.Vsix/Agoda.Analyzers.Vsix.csproj
+++ b/src/Agoda.Analyzers.Vsix/Agoda.Analyzers.Vsix.csproj
@@ -70,7 +70,6 @@
   <Target Name="BeforeBuild">
     <ItemGroup>
       <VSIXSourceItem Include="..\Agoda.Analyzers\bin\$(Configuration)\Agoda.Analyzers.dll" />
-      <VSIXSourceItem Include="..\Agoda.Analyzers.CodeFixes\bin\$(Configuration)\Agoda.Analyzers.CodeFixes.dll" />
     </ItemGroup>
   </Target>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Agoda.Analyzers.Vsix/source.extension.vsixmanifest
+++ b/src/Agoda.Analyzers.Vsix/source.extension.vsixmanifest
@@ -15,14 +15,10 @@
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Assets>
-    <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="Agoda.Analyzers.CodeFixes"
-           Path="|Agoda.Analyzers.CodeFixes|" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="Agoda.Analyzers"
            Path="|Agoda.Analyzers|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Agoda.Analyzers"
            Path="|Agoda.Analyzers|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Agoda.Analyzers.CodeFixes"
-           Path="|Agoda.Analyzers.CodeFixes|" />
   </Assets>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)"


### PR DESCRIPTION
I cloned repo and compiled but got error "Could not find project Agoda.Analyzers.CodeFixes referenced from source.extension.vsixmanifest. Please add a ProjectReference to Agoda.Analyzers.CodeFixes or correct project name in source.extension.vsixmanifest"

I assumed  `Agoda.Analyzers.CodeFixes` was removed but still have few references to it so I remove these references