### PR TITLE
Fix need for compile in release before debug works

### DIFF
--- a/src/Agoda.Analyzers/Agoda.Analyzers.csproj
+++ b/src/Agoda.Analyzers/Agoda.Analyzers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -49,11 +49,11 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 	<ItemGroup>
-		<None Include="bin\Release\netstandard2.0\Agoda.Analyzers.dll" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
-		<None Include="bin\Release\netstandard2.0\**\Agoda.Analyzers.resources.dll" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
-		<None Include="bin\Release\netstandard2.0\Agoda.Analyzers.pdb" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
+		<None Include="$(OutputPath)$(TargetFramework)\Agoda.Analyzers.dll" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
+		<None Include="$(OutputPath)$(TargetFramework)\**\Agoda.Analyzers.resources.dll" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
+		<None Include="$(OutputPath)$(TargetFramework)\Agoda.Analyzers.pdb" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
 		<Content Include="AgodaAnalyzersAgoji.png" Pack="true" PackagePath="">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 	</ItemGroup>
   <ItemGroup>

--- a/src/Agoda.Analyzers/Agoda.Analyzers.csproj
+++ b/src/Agoda.Analyzers/Agoda.Analyzers.csproj
@@ -49,11 +49,11 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 	<ItemGroup>
-		<None Include="$(OutputPath)$(TargetFramework)\Agoda.Analyzers.dll" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
-		<None Include="$(OutputPath)$(TargetFramework)\**\Agoda.Analyzers.resources.dll" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
-		<None Include="$(OutputPath)$(TargetFramework)\Agoda.Analyzers.pdb" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
+		<None Include="bin\$(Configuration)\netstandard2.0\Agoda.Analyzers.dll" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
+		<None Include="bin\$(Configuration)\netstandard2.0\**\Agoda.Analyzers.resources.dll" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
+		<None Include="bin\$(Configuration)\netstandard2.0\Agoda.Analyzers.pdb" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
 		<Content Include="AgodaAnalyzersAgoji.png" Pack="true" PackagePath="">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 	</ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Previously you would need to compile in release mode once first, so that the path was present before debug would work