### PR TITLE
Update codecov job to allow failure in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: src/Agoda.Analyzers.Test/results.cobertura.xml  # optional
-        fail_ci_if_error: true # optional (default = false)
+        fail_ci_if_error: false # optional (default = false)
 
   deploy:
     needs: build


### PR DESCRIPTION
Since the codecov job is failing with rate limit error (429), we need to bypass the job first to unblock the new analyzer rules.
Example failed job: https://github.com/agoda-com/AgodaAnalyzers/actions/runs/17462836764/job/49599652061?pr=217