### PR TITLE
Fix AG0045 false positive with logging statements

### DIFF
--- a/src/Agoda.Analyzers.Test/AgodaCustom/AG0045UnitTests.cs
+++ b/src/Agoda.Analyzers.Test/AgodaCustom/AG0045UnitTests.cs
@@ -227,4 +227,74 @@ class AG0045UnitTests : DiagnosticVerifier
 
         await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
     }
+
+    [Test]
+    public async Task AG0045_WhenUsingDollarSignInLogging_NoError()
+    {
+        var code = new CodeDescriptor
+        {
+            Code = @"
+                using System.Threading.Tasks;
+                using System.Linq;
+
+                class LogHelper
+                {
+                    public static string GetCommaSeparatedList(System.Collections.Generic.IEnumerable<int> items)
+                    {
+                        return string.Join("","", items);
+                    }
+                }
+
+                class GwModel
+                {
+                    public System.Collections.Generic.List<RateMutation> RatesMutationList { get; set; }
+                }
+
+                class RateMutation
+                {
+                    public int RatePlanId { get; set; }
+                }
+
+                class Logger
+                {
+                    public void Information(string message) { }
+                }
+
+                class TestClass
+                {
+                    private Logger _logger = new Logger();
+
+                    public void TestMethod()
+                    {
+                        var gwModel = new GwModel();
+                        _logger.Information($""Updating mutation for A variant "" +
+                                            $""${LogHelper.GetCommaSeparatedList(gwModel
+                                                .RatesMutationList?
+                                                .Select(x => x.RatePlanId))}"");
+                    }
+                }"
+        };
+
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
+
+    [Test]
+    public async Task AG0045_WhenUsingDoubleSlashInNonXPathContext_NoError()
+    {
+        var code = new CodeDescriptor
+        {
+            Code = @"
+                class TestClass
+                {
+                    public void TestMethod()
+                    {
+                        string url = ""https://example.com//path"";
+                        string comment = ""// This is a comment"";
+                        string regex = ""//d+"";
+                    }
+                }"
+        };
+
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
 } 

--- a/src/Agoda.Analyzers/AgodaCustom/AG0045XPathShouldNotBeUsedInPlaywrightLocators.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0045XPathShouldNotBeUsedInPlaywrightLocators.cs
@@ -43,7 +43,7 @@ namespace Agoda.Analyzers.AgodaCustom
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
 
-        private static readonly Regex XPathPattern = new Regex(@"^(xpath=|//|\.\./|ancestor::|following-sibling::|preceding-sibling::|parent::|child::|descendant::|ancestor-or-self::|descendant-or-self::|following::|preceding::|self::)");
+        private static readonly Regex XPathPattern = new Regex(@"^(xpath=|//[a-zA-Z@\[\*]|\.\./|ancestor::|following-sibling::|preceding-sibling::|parent::|child::|descendant::|ancestor-or-self::|descendant-or-self::|following::|preceding::|self::)");
 
         public override void Initialize(AnalysisContext context)
         {


### PR DESCRIPTION
- Improve XPath pattern to be more specific and avoid matching non-XPath strings
- Change pattern from //$ to //[a-zA-Z@\[\*] to avoid matching dollar signs in string interpolation
- Add test cases for logging statements with $ and double slashes in non-XPath contexts
- Ensures AG0045 only triggers for actual XPath expressions in Playwright locators