### PR TITLE
Improve AG0045 XPath pattern to avoid false positives with URLs

### DIFF
--- a/src/Agoda.Analyzers/AgodaCustom/AG0045XPathShouldNotBeUsedInPlaywrightLocators.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0045XPathShouldNotBeUsedInPlaywrightLocators.cs
@@ -43,7 +43,7 @@ namespace Agoda.Analyzers.AgodaCustom
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
 
-        private static readonly Regex XPathPattern = new Regex(@"^(xpath=|//[@\[\*]|//[a-zA-Z][a-zA-Z0-9\-_]*(\[|$)|\.\./|/\*|ancestor::|following-sibling::|preceding-sibling::|parent::|child::|descendant::|ancestor-or-self::|descendant-or-self::|following::|preceding::|self::)");
+        private static readonly Regex XPathPattern = new Regex(@"^(xpath=|//\*|//[@\[\*]|//[a-zA-Z][a-zA-Z0-9\-_]*\[|\.\./|/\*|ancestor::|following-sibling::|preceding-sibling::|parent::|child::|descendant::|ancestor-or-self::|descendant-or-self::|following::|preceding::|self::)");
 
         public override void Initialize(AnalysisContext context)
         {


### PR DESCRIPTION
- Refine XPath pattern to be more specific
- This ensures only actual XPath expressions are detected, not URLs
- Add comprehensive test cases for common URL patterns
- Maintain detection of actual XPath expressions with brackets or wildcards
- All 31 AG0045 tests passing, including new comprehensive coverage