### PR TITLE
Improve AG0012 assertion coverage for Shouldly, NSubstitute, and FluentAssertions

### DIFF
--- a/doc/AG0012.md
+++ b/doc/AG0012.md
@@ -58,6 +58,23 @@ public class TestClass
 }
 ```
 
+With FluentAssertions:
+
+```csharp
+using NUnit.Framework;
+using FluentAssertions;
+
+public class TestClass
+{
+    [Test]
+    public void This_Is_Valid()
+    {
+        int result = 1;
+        result.Should().Be(1);
+    }
+}
+```
+
 With NSubstitute (behavioral verification):
 
 ```csharp

--- a/doc/AG0012.md
+++ b/doc/AG0012.md
@@ -58,6 +58,33 @@ public class TestClass
 }
 ```
 
+With NSubstitute (behavioral verification):
+
+```csharp
+using NUnit.Framework;
+using NSubstitute;
+
+public class TestClass
+{
+    [Test]
+    public void Should_Call_Service()
+    {
+        var service = Substitute.For<IService>();
+        service.Execute();
+        service.Received().Execute();
+    }
+}
+```
+
+### Recognized assertion libraries
+
+| Library | Recognized patterns |
+|---------|-------------------|
+| NUnit | `Assert.That(...)`, `Assert.AreEqual(...)`, etc. |
+| Shouldly | All `Should*` extension methods (`ShouldBe`, `ShouldContain`, `ShouldThrow`, etc.) |
+| NSubstitute | `Received()`, `DidNotReceive()`, `ReceivedWithAnyArgs()`, `DidNotReceiveWithAnyArgs()` |
+| FluentAssertions | `.Should().Be(...)`, `.Should().BeEquivalentTo(...)`, etc. |
+
 Tests without assertions create problems:
 
 - Don't actually verify any behavior

--- a/src/Agoda.Analyzers.Test/Agoda.Analyzers.Test.csproj
+++ b/src/Agoda.Analyzers.Test/Agoda.Analyzers.Test.csproj
@@ -71,6 +71,7 @@
     <PackageReference Include="Microsoft.Playwright" Version="1.47.0" />
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Selenium.WebDriver" Version="3.14.0" />

--- a/src/Agoda.Analyzers.Test/AgodaCustom/AG0012UnitTests.cs
+++ b/src/Agoda.Analyzers.Test/AgodaCustom/AG0012UnitTests.cs
@@ -138,10 +138,10 @@ internal class AG0012UnitTests : DiagnosticVerifier
 
                     namespace Tests
                     {
-                        internal class TestClass
+                        public class TestClass
                         {
                             [Test]
-                            internal void This_Is_Valid()
+                            public void This_Is_Valid()
                             {
                                 int arrayToAssert = 1;
                                 arrayToAssert.Should().Be(1);

--- a/src/Agoda.Analyzers.Test/AgodaCustom/AG0012UnitTests.cs
+++ b/src/Agoda.Analyzers.Test/AgodaCustom/AG0012UnitTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
+using NSubstitute;
 
 namespace Agoda.Analyzers.Test.AgodaCustom;
 
@@ -268,5 +269,158 @@ internal class AG0012UnitTests : DiagnosticVerifier
         };
 
         await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
+
+    [Test]
+    public async Task AG0012_WithShouldlyShouldContain_ShouldNotShowWarning()
+    {
+        var code = new CodeDescriptor
+        {
+            References = new[] { typeof(TestFixtureAttribute).Assembly, typeof(Shouldly.Should).Assembly },
+            Code = @"
+                    using NUnit.Framework;
+                    using Shouldly;
+                    using System.Collections.Generic;
+                    
+                    namespace Tests
+                    {
+                        public class TestClass
+                        {
+                            [Test]
+                            public void List_ShouldContain_Item()
+                            {
+                                var list = new List<int> { 1, 2, 3 };
+                                list.ShouldContain(2);
+                            }
+                        }
+                    }"
+        };
+
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
+
+    [Test]
+    public async Task AG0012_WithShouldlyShouldNotThrow_ShouldNotShowWarning()
+    {
+        var code = new CodeDescriptor
+        {
+            References = new[] { typeof(TestFixtureAttribute).Assembly, typeof(Shouldly.Should).Assembly },
+            Code = @"
+                    using NUnit.Framework;
+                    using Shouldly;
+                    using System;
+                    
+                    namespace Tests
+                    {
+                        public class TestClass
+                        {
+                            [Test]
+                            public void Action_ShouldNotThrow()
+                            {
+                                Action action = () => { var x = 1; };
+                                action.ShouldNotThrow();
+                            }
+                        }
+                    }"
+        };
+
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
+
+    [Test]
+    public async Task AG0012_WithNSubstituteReceived_ShouldNotShowWarning()
+    {
+        var code = new CodeDescriptor
+        {
+            References = new[] { typeof(TestFixtureAttribute).Assembly, typeof(Substitute).Assembly },
+            Code = @"
+                    using NUnit.Framework;
+                    using NSubstitute;
+                    
+                    namespace Tests
+                    {
+                        public interface IService
+                        {
+                            void Execute();
+                        }
+
+                        public class TestClass
+                        {
+                            [Test]
+                            public void Service_ShouldReceiveCall()
+                            {
+                                IService service = Substitute.For<IService>();
+                                service.Execute();
+                                service.Received().Execute();
+                            }
+                        }
+                    }"
+        };
+
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
+
+    [Test]
+    public async Task AG0012_WithNSubstituteDidNotReceive_ShouldNotShowWarning()
+    {
+        var code = new CodeDescriptor
+        {
+            References = new[] { typeof(TestFixtureAttribute).Assembly, typeof(Substitute).Assembly },
+            Code = @"
+                    using NUnit.Framework;
+                    using NSubstitute;
+                    
+                    namespace Tests
+                    {
+                        public interface IService
+                        {
+                            void Execute();
+                        }
+
+                        public class TestClass
+                        {
+                            [Test]
+                            public void Service_ShouldNotReceiveCall()
+                            {
+                                IService service = Substitute.For<IService>();
+                                service.DidNotReceive().Execute();
+                            }
+                        }
+                    }"
+        };
+
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
+
+    [Test]
+    public async Task AG0012_WithNSubstituteReturnsOnly_ShouldShowWarning()
+    {
+        var code = new CodeDescriptor
+        {
+            References = new[] { typeof(TestFixtureAttribute).Assembly, typeof(Substitute).Assembly },
+            Code = @"
+                    using NUnit.Framework;
+                    using NSubstitute;
+                    
+                    namespace Tests
+                    {
+                        public interface ICalculator
+                        {
+                            int Add(int a, int b);
+                        }
+
+                        public class TestClass
+                        {
+                            [Test]
+                            public void Setup_Without_Assertion_Is_NotValid()
+                            {
+                                ICalculator calc = Substitute.For<ICalculator>();
+                                calc.Add(1, 2).Returns(3);
+                            }
+                        }
+                    }"
+        };
+
+        await VerifyDiagnosticsAsync(code, new DiagnosticLocation(14, 29));
     }
 }

--- a/src/Agoda.Analyzers/AgodaCustom/AG0012TestMethodMustContainAtLeastOneAssertion.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0012TestMethodMustContainAtLeastOneAssertion.cs
@@ -43,7 +43,11 @@ namespace Agoda.Analyzers.AgodaCustom
         private static readonly AssertLibraryInfo[] AssertionLibraryList =
         {
             new AssertLibraryInfo("NUnit.Framework", "nunit.framework.dll", "Assert"),
-            new AssertLibraryInfo("Shouldly", "Shouldly.dll", "Should", "Shouldly.Should"),
+            new AssertLibraryInfo("Shouldly", "Shouldly.dll", "Should", "Shouldly."),
+            new AssertLibraryInfo("NSubstitute", "NSubstitute.dll", "SubstituteExtensions", "NSubstitute.SubstituteExtensions",
+                new[] { "Received", "DidNotReceive", "ReceivedWithAnyArgs", "DidNotReceiveWithAnyArgs" }),
+            new AssertLibraryInfo("NSubstitute.ReceivedExtensions", "NSubstitute.dll", "ReceivedExtensions",
+                "NSubstitute.ReceivedExtensions.ReceivedExtensions"),
             //FluentAssertions
         };
 
@@ -118,7 +122,8 @@ namespace Agoda.Analyzers.AgodaCustom
                         && symbol.ContainingType != null
                         && symbol.ContainingNamespace.ToDisplayString() == lib.Namespace
                         && symbol.ContainingModule.ToDisplayString() == lib.Module
-                        && symbol.ContainingType.ToDisplayString().StartsWith(lib.Type)));
+                        && symbol.ContainingType.ToDisplayString().StartsWith(lib.Type)
+                        && (lib.AssertMethodNames == null || lib.AssertMethodNames.Contains(symbol.Name))));
         }
 
         private class AssertLibraryInfo
@@ -128,14 +133,17 @@ namespace Agoda.Analyzers.AgodaCustom
             public string Name { get; }
             public string Type { get; }
             public bool HasExtenstionMethods { get; }
+            public string[] AssertMethodNames { get; }
 
-            public AssertLibraryInfo(string namespaceTitle, string module, string name, string type = null)
+            public AssertLibraryInfo(string namespaceTitle, string module, string name, string type = null,
+                string[] assertMethodNames = null)
             {
                 Namespace = namespaceTitle;
                 Module = module;
                 Name = name;
                 Type = type;
                 HasExtenstionMethods = type != null;
+                AssertMethodNames = assertMethodNames;
             }
         }
         private static Dictionary<string, string> _props = new Dictionary<string, string>()

--- a/src/Agoda.Analyzers/AgodaCustom/AG0012TestMethodMustContainAtLeastOneAssertion.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0012TestMethodMustContainAtLeastOneAssertion.cs
@@ -48,7 +48,7 @@ namespace Agoda.Analyzers.AgodaCustom
                 new[] { "Received", "DidNotReceive", "ReceivedWithAnyArgs", "DidNotReceiveWithAnyArgs" }),
             new AssertLibraryInfo("NSubstitute.ReceivedExtensions", "NSubstitute.dll", "ReceivedExtensions",
                 "NSubstitute.ReceivedExtensions.ReceivedExtensions"),
-            //FluentAssertions
+            new AssertLibraryInfo("FluentAssertions", "FluentAssertions.dll", "AssertionExtensions", "FluentAssertions."),
         };
 
         public override void Initialize(AnalysisContext context)


### PR DESCRIPTION
## Summary

- **Broadened Shouldly detection**: Changed extension type match from `Shouldly.Should` prefix to `Shouldly.` namespace prefix, so all Shouldly extension methods (e.g. `ShouldBeEquivalentTo`, `ShouldNotThrow`, `ShouldContain`) are recognized as assertions, not just those on `Shouldly.Should*` classes.
- **Added NSubstitute verification support**: `Received()`, `DidNotReceive()`, `ReceivedWithAnyArgs()`, and `DidNotReceiveWithAnyArgs()` are now recognized as assertions. Method-name filtering ensures non-assertion methods like `Returns()` are not falsely counted.
- **Added FluentAssertions support**: `.Should().Be(...)`, `.Should().BeEquivalentTo(...)`, etc. are now recognized as assertions. Also fixed the existing test which was falsely passing due to using `internal` methods that bypassed the analyzer's public-method check.
- **Added `AssertMethodNames` to `AssertLibraryInfo`**: Optional method-name filter for libraries (like NSubstitute) where assertion and non-assertion methods share the same containing type.

## Motivation

Developers were adding workaround assertions (`Assert.Pass()`, `true.ShouldBeTrue()`) to satisfy AG0012 when using legitimate assertion patterns that the rule didn't recognize. This was identified via Sourcegraph analysis of `full-stack/supply` repositories.

## Changes

| File | Change |
|------|--------|
| `AG0012TestMethodMustContainAtLeastOneAssertion.cs` | Broadened Shouldly match, added NSubstitute + FluentAssertions entries, added `AssertMethodNames` filtering |
| `AG0012UnitTests.cs` | Added 5 new tests, fixed FluentAssertions test visibility (`internal` → `public`) |
| `Agoda.Analyzers.Test.csproj` | Added NSubstitute 5.3.0 test dependency |
| `doc/AG0012.md` | Added FluentAssertions + NSubstitute examples and recognized-libraries table |

## Test plan

- [x] All 15 AG0012 tests pass (including fixed FluentAssertions test)
- [x] Full test suite shows no regressions (7 pre-existing failures in unrelated SA1106/SA1123 analyzers)
- [x] Negative test confirms NSubstitute `Returns()` alone still triggers warning
- [x] FluentAssertions test now properly validates detection (previously passed due to `internal` bypass)