### PR TITLE
Reduce AG0051 false positives

### DIFF
--- a/doc/AG0051.md
+++ b/doc/AG0051.md
@@ -2,11 +2,11 @@
 
 ## Cause
 
-A hardcoded `DateTime` or `DateTimeOffset` value is used in test code (e.g. `new DateTime(2025, 12, 31)` or `DateTime.Parse("2025-12-31")`).
+A high-confidence hardcoded `DateTime` or `DateTimeOffset` value is used in test code (e.g. `new DateTime(2099, 12, 31)` or `DateTime.Parse("2099-12-31")`).
 
 ## Rule description
 
-Hardcoded dates in test fixtures act as "timebombs" — tests that pass today but fail when the calendar rolls past the hardcoded date. This is a recurring source of flakey tests that accounts for ~13% of all flakey test fixes.
+Hardcoded future dates in test fixtures can act as "timebombs" - tests that pass today but fail when the calendar rolls past the hardcoded date. This is a recurring source of flakey tests that accounts for ~13% of all flakey test fixes.
 
 The failure appears unrelated to any code change, making debugging misleading ("what changed?" is a red herring — nothing changed, the calendar did).
 
@@ -16,7 +16,7 @@ Use relative date offsets instead of hardcoded dates:
 
 ```csharp
 // Instead of:
-var date = new DateTime(2025, 12, 31);
+var date = new DateTime(2099, 12, 31);
 
 // Use:
 var date = DateTime.Today.AddDays(30);
@@ -25,7 +25,20 @@ var date = DateTime.Today.AddDays(30);
 var date = DateTimeOffset.UtcNow.AddDays(30);
 ```
 
-Dates far in the past (before 2020) are considered safe for historical test data and are not flagged.
+## Suppression rules
+
+AG0051 does not report dates that are unlikely to be time bombs:
+
+- Dates whose whole month has already elapsed relative to analyzer process start time
+- Sentinel dates with year `2999` or later, such as `2999-12-31` or `9999-12-31`
+- Dates assigned to non-risky object initializer properties, such as `DisplayDate`
+- Dates passed directly into assertion methods, such as `ShouldBe(...)` or `Assert.AreEqual(...)`
+
+Dates assigned to risky range or expiry-style properties still report even inside object initializers. Examples include `StartDate`, `EndDate`, `CheckIn`, `CheckOut`, `Expiry`, `Expiration`, `ExpiresAt`, `ValidFrom`, and `ValidTo`.
+
+Past-date suppression is intentionally time-dependent. The same commit can report AG0051 before a fixed fixture date has elapsed and stop reporting after the calendar moves past the entire fixture month. The analyzer computes the analysis date once per process, so a single build remains self-consistent.
+
+Reported AG0051 diagnostics include a `confidence=high` diagnostic property for downstream tooling.
 
 ## Scope
 

--- a/src/Agoda.Analyzers.Test/AgodaCustom/AG0051UnitTests.cs
+++ b/src/Agoda.Analyzers.Test/AgodaCustom/AG0051UnitTests.cs
@@ -1,3 +1,6 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Agoda.Analyzers.AgodaCustom;
 using Agoda.Analyzers.Test.Helpers;
@@ -13,6 +16,8 @@ internal class AG0051UnitTests : DiagnosticVerifier
 
     protected override string DiagnosticId => AG0051DetectHardcodedDateLiterals.DiagnosticId;
 
+    private const int FutureYear = 2899;
+
     private static string WrapInTestNamespace(string body) =>
         @"
 using System;
@@ -21,58 +26,58 @@ namespace MyApp.Tests {" + body + @"
 ";
 
     [Test]
-    public async Task AG0051_NewDateTimeWithRecentHardcodedDate_ShouldShowWarning()
+    public async Task AG0051_NewDateTimeWithFutureHardcodedDate_ShouldShowWarning()
     {
-        var code = WrapInTestNamespace(@"
+        var code = WrapInTestNamespace($@"
 class TestClass
-{
+{{
     public void TestMethod()
-    {
-        var date = new DateTime(2025, 12, 31);
-    }
-}");
+    {{
+        var date = new DateTime({FutureYear}, 12, 31);
+    }}
+}}");
         await VerifyDiagnosticsAsync(code, new DiagnosticLocation(8, 20));
     }
 
     [Test]
     public async Task AG0051_NewDateTimeOffsetWithHardcodedDate_ShouldShowWarning()
     {
-        var code = WrapInTestNamespace(@"
+        var code = WrapInTestNamespace($@"
 class TestClass
-{
+{{
     public void TestMethod()
-    {
-        var date = new DateTimeOffset(2025, 8, 15, 12, 0, 0, TimeSpan.Zero);
-    }
-}");
+    {{
+        var date = new DateTimeOffset({FutureYear}, 8, 15, 12, 0, 0, TimeSpan.Zero);
+    }}
+}}");
         await VerifyDiagnosticsAsync(code, new DiagnosticLocation(8, 20));
     }
 
     [Test]
     public async Task AG0051_DateTimeParseWithHardcodedString_ShouldShowWarning()
     {
-        var code = WrapInTestNamespace(@"
+        var code = WrapInTestNamespace($@"
 class TestClass
-{
+{{
     public void TestMethod()
-    {
-        var date = DateTime.Parse(""2025-12-31"");
-    }
-}");
+    {{
+        var date = DateTime.Parse(""{FutureYear}-12-31"");
+    }}
+}}");
         await VerifyDiagnosticsAsync(code, new DiagnosticLocation(8, 20));
     }
 
     [Test]
     public async Task AG0051_DateTimeOffsetParseWithHardcodedString_ShouldShowWarning()
     {
-        var code = WrapInTestNamespace(@"
+        var code = WrapInTestNamespace($@"
 class TestClass
-{
+{{
     public void TestMethod()
-    {
-        var date = DateTimeOffset.Parse(""2025-12-31T00:00:00Z"");
-    }
-}");
+    {{
+        var date = DateTimeOffset.Parse(""{FutureYear}-12-31T00:00:00Z"");
+    }}
+}}");
         await VerifyDiagnosticsAsync(code, new DiagnosticLocation(8, 20));
     }
 
@@ -135,30 +140,30 @@ class TestClass
     [Test]
     public async Task AG0051_NewDateTimeWithVariableArgs_ShouldNotShowWarning()
     {
-        var code = WrapInTestNamespace(@"
+        var code = WrapInTestNamespace($@"
 class TestClass
-{
+{{
     public void TestMethod()
-    {
-        int year = 2025;
+    {{
+        int year = {FutureYear};
         var date = new DateTime(year, 12, 31);
-    }
-}");
+    }}
+}}");
         await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
     }
 
     [Test]
     public async Task AG0051_MultipleDateTimeLiterals_ShouldShowMultipleWarnings()
     {
-        var code = WrapInTestNamespace(@"
+        var code = WrapInTestNamespace($@"
 class TestClass
-{
+{{
     public void TestMethod()
-    {
-        var checkIn = new DateTime(2025, 12, 31);
-        var checkOut = new DateTime(2026, 1, 5);
-    }
-}");
+    {{
+        var checkIn = new DateTime({FutureYear}, 12, 31);
+        var checkOut = new DateTime({FutureYear + 1}, 1, 5);
+    }}
+}}");
         await VerifyDiagnosticsAsync(code, new[]
         {
             new DiagnosticLocation(8, 23),
@@ -181,7 +186,7 @@ class TestClass
     }
 
     [Test]
-    public async Task AG0051_NewDateTimeWith2020Date_ShouldShowWarning()
+    public async Task AG0051_NewDateTimeWithPast2020Date_ShouldNotShowWarning()
     {
         var code = WrapInTestNamespace(@"
 class TestClass
@@ -191,7 +196,7 @@ class TestClass
         var date = new DateTime(2020, 6, 15);
     }
 }");
-        await VerifyDiagnosticsAsync(code, new DiagnosticLocation(8, 20));
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
     }
 
     [Test]
@@ -211,48 +216,48 @@ class TestClass
     [Test]
     public async Task AG0051_DateTimeParseWithSlashFormat_ShouldShowWarning()
     {
-        var code = WrapInTestNamespace(@"
+        var code = WrapInTestNamespace($@"
 class TestClass
-{
+{{
     public void TestMethod()
-    {
-        var date = DateTime.Parse(""2025/06/15"");
-    }
-}");
+    {{
+        var date = DateTime.Parse(""{FutureYear}/06/15"");
+    }}
+}}");
         await VerifyDiagnosticsAsync(code, new DiagnosticLocation(8, 20));
     }
 
     [Test]
     public async Task AG0051_FieldInitializerWithHardcodedDate_ShouldShowWarning()
     {
-        var code = WrapInTestNamespace(@"
+        var code = WrapInTestNamespace($@"
 class TestClass
-{
-    private readonly DateTime _endDate = new DateTime(2025, 3, 31);
+{{
+    private readonly DateTime _endDate = new DateTime({FutureYear}, 3, 31);
 
     public void TestMethod()
-    {
-    }
-}");
+    {{
+    }}
+}}");
         await VerifyDiagnosticsAsync(code, new DiagnosticLocation(6, 42));
     }
 
     [Test]
     public async Task AG0051_NonTestNamespace_ShouldNotShowWarning()
     {
-        var code = @"
+        var code = $@"
 using System;
 
 namespace MyApp.Services
-{
+{{
     class DateService
-    {
+    {{
         public void SetDate()
-        {
-            var date = new DateTime(2025, 12, 31);
-        }
-    }
-}
+        {{
+            var date = new DateTime({FutureYear}, 12, 31);
+        }}
+    }}
+}}
 ";
         await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
     }
@@ -260,20 +265,141 @@ namespace MyApp.Services
     [Test]
     public async Task AG0051_TestsNamespaceVariant_ShouldShowWarning()
     {
-        var code = @"
+        var code = $@"
 using System;
 
 namespace MyApp.IntegrationTests.Booking
-{
+{{
     class BookingTests
-    {
+    {{
         public void TestMethod()
-        {
-            var date = new DateTime(2025, 12, 31);
-        }
-    }
-}
+        {{
+            var date = new DateTime({FutureYear}, 12, 31);
+        }}
+    }}
+}}
 ";
         await VerifyDiagnosticsAsync(code, new DiagnosticLocation(10, 24));
+    }
+
+    [Test]
+    public async Task AG0051_DateTimeParseWithPast2020Date_ShouldNotShowWarning()
+    {
+        var code = WrapInTestNamespace(@"
+class TestClass
+{
+    public void TestMethod()
+    {
+        var date = DateTime.Parse(""2020-06-15"");
+    }
+}");
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
+
+    [Test]
+    public async Task AG0051_NewDateTimeWithSentinelYear_ShouldNotShowWarning()
+    {
+        var code = WrapInTestNamespace(@"
+class TestClass
+{
+    public void TestMethod()
+    {
+        var date = new DateTime(9999, 12, 31);
+    }
+}");
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
+
+    [Test]
+    public async Task AG0051_DateTimeParseWithSentinelYear_ShouldNotShowWarning()
+    {
+        var code = WrapInTestNamespace(@"
+class TestClass
+{
+    public void TestMethod()
+    {
+        var date = DateTime.Parse(""2999-12-31"");
+    }
+}");
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
+
+    [Test]
+    public async Task AG0051_NewDateTimeAssignedToLowRiskObjectInitializerProperty_ShouldNotShowWarning()
+    {
+        var code = WrapInTestNamespace($@"
+class TestClass
+{{
+    class ExpectedDto {{ public DateTime DisplayDate {{ get; set; }} }}
+
+    public void TestMethod()
+    {{
+        var expected = new ExpectedDto {{ DisplayDate = new DateTime({FutureYear}, 12, 31) }};
+    }}
+}}");
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
+
+    [Test]
+    public async Task AG0051_NewDateTimeAssignedToRiskyObjectInitializerProperty_ShouldShowWarning()
+    {
+        var code = WrapInTestNamespace($@"
+class TestClass
+{{
+    class Offer {{ public DateTime StartDate {{ get; set; }} }}
+
+    public void TestMethod()
+    {{
+        var offer = new Offer {{ StartDate = new DateTime({FutureYear}, 12, 31) }};
+    }}
+}}");
+        await VerifyDiagnosticsAsync(code, new DiagnosticLocation(10, 45));
+    }
+
+    [Test]
+    public async Task AG0051_NewDateTimeUsedAsAssertionArgument_ShouldNotShowWarning()
+    {
+        var code = WrapInTestNamespace($@"
+static class AssertionExtensions
+{{
+    public static void ShouldBe<T>(this T actual, T expected)
+    {{
+    }}
+}}
+
+class TestClass
+{{
+    public void TestMethod()
+    {{
+        var actual = DateTime.Today;
+        actual.ShouldBe(new DateTime({FutureYear}, 12, 31));
+    }}
+}}");
+        await VerifyDiagnosticsAsync(code, EmptyDiagnosticResults);
+    }
+
+    [Test]
+    public async Task AG0051_FutureHardcodedDateDiagnostic_ShouldIncludeHighConfidence()
+    {
+        var code = WrapInTestNamespace($@"
+class TestClass
+{{
+    public void TestMethod()
+    {{
+        var date = new DateTime({FutureYear}, 12, 31);
+    }}
+}}");
+
+        var document = CreateProject(new[] { code }).Documents.First();
+        var diagnostics = await GetSortedDiagnosticsFromDocumentsAsync(
+            ImmutableArray.Create(DiagnosticAnalyzer),
+            new[] { document },
+            CancellationToken.None);
+
+        Assert.AreEqual(1, diagnostics.Length);
+        Assert.IsTrue(diagnostics[0].Properties.TryGetValue(
+            AG0051DetectHardcodedDateLiterals.ConfidencePropertyName,
+            out var confidence));
+        Assert.AreEqual(AG0051DetectHardcodedDateLiterals.HighConfidence, confidence);
     }
 }

--- a/src/Agoda.Analyzers/AgodaCustom/AG0051DetectHardcodedDateLiterals.cs
+++ b/src/Agoda.Analyzers/AgodaCustom/AG0051DetectHardcodedDateLiterals.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Agoda.Analyzers.Helpers;
@@ -15,6 +16,8 @@ namespace Agoda.Analyzers.AgodaCustom
     public class AG0051DetectHardcodedDateLiterals : DiagnosticAnalyzer
     {
         public const string DiagnosticId = "AG0051";
+        public const string ConfidencePropertyName = "confidence";
+        public const string HighConfidence = "high";
 
         private static readonly LocalizableString Title = new LocalizableResourceString(
             nameof(CustomRulesResources.AG0051Title),
@@ -48,7 +51,9 @@ namespace Agoda.Analyzers.AgodaCustom
                 { AnalyzerConstants.KEY_TECH_DEBT_IN_MINUTES, "10" }
             }.ToImmutableDictionary();
 
-        private const int SafeYearThreshold = 2020;
+        private const int SentinelYearThreshold = 2999;
+
+        private static readonly DateTime AnalysisDate = DateTime.UtcNow.Date;
 
         private static readonly Regex DateStringPattern = new Regex(
             @"^\d{4}[-/]\d{1,2}[-/]\d{1,2}($|[T\s])",
@@ -60,7 +65,35 @@ namespace Agoda.Analyzers.AgodaCustom
             "Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute",
         };
 
-        private static readonly char[] DateSeparators = { '-', '/' };
+        private static readonly HashSet<string> AssertionMethods = new HashSet<string>
+        {
+            "ShouldBe",
+            "ShouldBeEquivalentTo",
+            "AreEqual",
+            "Equal",
+            "Be",
+            "BeEquivalentTo",
+        };
+
+        private static readonly HashSet<string> RiskyPropertyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "StartDate",
+            "EndDate",
+            "From",
+            "To",
+            "Expiry",
+            "Expiration",
+            "ExpiresAt",
+            "CheckIn",
+            "CheckOut",
+            "CheckInDate",
+            "CheckOutDate",
+            "ValidFrom",
+            "ValidTo",
+            "PayableDate",
+            "FirstLiveDate",
+            "EffectiveDate",
+        };
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -95,15 +128,13 @@ namespace Agoda.Analyzers.AgodaCustom
             if (!AllArgumentsAreLiterals(arguments.Value.Take(3)))
                 return;
 
-            var yearArg = arguments.Value[0].Expression as LiteralExpressionSyntax;
-            if (yearArg == null || !yearArg.IsKind(SyntaxKind.NumericLiteralExpression))
+            if (!TryGetDateParts(arguments.Value, out var year, out var month, out var day))
                 return;
 
-            var year = (int)yearArg.Token.Value;
-            if (year < SafeYearThreshold)
+            if (IsSentinelDate(year) || IsPastDate(year, month, day) || IsLowRiskUsage(creation))
                 return;
 
-            context.ReportDiagnostic(Diagnostic.Create(Rule, creation.GetLocation(), Properties));
+            context.ReportDiagnostic(CreateDiagnostic(creation));
         }
 
         private void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
@@ -141,10 +172,23 @@ namespace Agoda.Analyzers.AgodaCustom
             if (!DateStringPattern.IsMatch(dateString))
                 return;
 
-            if (TryExtractYear(dateString, out var year) && year < SafeYearThreshold)
+            if (!DateTime.TryParse(dateString, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate))
                 return;
 
-            context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), Properties));
+            if (IsSentinelDate(parsedDate.Year) ||
+                IsPastDate(parsedDate.Year, parsedDate.Month, parsedDate.Day) ||
+                IsLowRiskUsage(invocation))
+                return;
+
+            context.ReportDiagnostic(CreateDiagnostic(invocation));
+        }
+
+        private static Diagnostic CreateDiagnostic(SyntaxNode node)
+        {
+            return Diagnostic.Create(
+                Rule,
+                node.GetLocation(),
+                Properties.Add(ConfidencePropertyName, HighConfidence));
         }
 
         private static bool IsInTestContext(SyntaxNodeAnalysisContext context)
@@ -205,14 +249,87 @@ namespace Agoda.Analyzers.AgodaCustom
                                         && literal.IsKind(SyntaxKind.NumericLiteralExpression));
         }
 
-        private static bool TryExtractYear(string dateString, out int year)
+        private static bool TryGetDateParts(SeparatedSyntaxList<ArgumentSyntax> arguments, out int year, out int month, out int day)
         {
             year = 0;
-            var dashIndex = dateString.IndexOfAny(DateSeparators);
-            if (dashIndex <= 0)
+            month = 0;
+            day = 0;
+
+            return TryGetIntLiteral(arguments[0], out year) &&
+                   TryGetIntLiteral(arguments[1], out month) &&
+                   TryGetIntLiteral(arguments[2], out day);
+        }
+
+        private static bool TryGetIntLiteral(ArgumentSyntax argument, out int value)
+        {
+            value = 0;
+            var literal = argument.Expression as LiteralExpressionSyntax;
+            if (literal == null || !literal.IsKind(SyntaxKind.NumericLiteralExpression))
                 return false;
 
-            return int.TryParse(dateString.Substring(0, dashIndex), out year);
+            if (literal.Token.Value is int intValue)
+            {
+                value = intValue;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsSentinelDate(int year)
+        {
+            return year >= SentinelYearThreshold;
+        }
+
+        private static bool IsPastDate(int year, int month, int day)
+        {
+            if (year < 1 || year > 9999 || month < 1 || month > 12 || day < 1 || day > 31)
+                return false;
+
+            return new DateTime(year, month, 1).AddMonths(1) < AnalysisDate;
+        }
+
+        private static bool IsLowRiskUsage(SyntaxNode node)
+        {
+            if (IsLowRiskObjectInitializerAssignment(node))
+                return true;
+
+            var argument = node.Parent as ArgumentSyntax;
+            var invocation = argument?.Parent?.Parent as InvocationExpressionSyntax;
+            return invocation != null &&
+                   TryGetInvokedName(invocation, out var invokedName) &&
+                   AssertionMethods.Contains(invokedName);
+        }
+
+        private static bool IsLowRiskObjectInitializerAssignment(SyntaxNode node)
+        {
+            var assignment = node.Parent as AssignmentExpressionSyntax;
+            if (assignment == null || !(assignment.Parent is InitializerExpressionSyntax))
+                return false;
+
+            var identifierName = assignment.Left as IdentifierNameSyntax;
+            return identifierName != null && !RiskyPropertyNames.Contains(identifierName.Identifier.Text);
+        }
+
+        private static bool TryGetInvokedName(InvocationExpressionSyntax invocation, out string name)
+        {
+            name = null;
+
+            var memberAccess = invocation.Expression as MemberAccessExpressionSyntax;
+            if (memberAccess != null)
+            {
+                name = memberAccess.Name.Identifier.Text;
+                return !string.IsNullOrEmpty(name);
+            }
+
+            var identifierName = invocation.Expression as IdentifierNameSyntax;
+            if (identifierName != null)
+            {
+                name = identifierName.Identifier.Text;
+                return !string.IsNullOrEmpty(name);
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Refs #241

## Summary
- suppress AG0051 for dates whose full month has already elapsed at analysis time
- suppress sentinel years `>= 2999` in object creation and parse paths
- suppress low-risk object-initializer and assertion-argument usages while keeping risky range/expiry property names flagged
- add `confidence=high` to reported diagnostics and document the time-dependent suppression behavior

P3 frozen-clock detection is intentionally left for the follow-up PR called out in the issue checklist.

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet test src/Agoda.Analyzers.Test/Agoda.Analyzers.Test.csproj --filter "FullyQualifiedName~AG0051" --no-restore --verbosity minimal`
- `DOTNET_ROLL_FORWARD=Major dotnet test src/Agoda.Analyzers.Test/Agoda.Analyzers.Test.csproj --filter "FullyQualifiedName!~StyleCop" --no-restore --verbosity minimal`

Local note: this machine only has the .NET 10 runtime installed, so the net8 testhost needs `DOTNET_ROLL_FORWARD=Major`. The unfiltered suite fails only in existing StyleCop code-fix newline expectations under that rolled-forward runtime.